### PR TITLE
fixed lib-subdir path for gtkada_gl installation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -105,7 +105,7 @@ install/%: force
 ifeq (${HAVE_OPENGL}, True)
 	${GPRINSTALL_FULL} -XLIBRARY_TYPE=$(@F) --build-name=$(@F) \
 		--sources-subdir=include/gtkada/gtkada_gl.$(@F) \
-		--lib-subdir=${libdir}/gtkada/gtkada_gl.$(@F) \
+		--lib-subdir=lib/gtkada/gtkada_gl.$(@F) \
 		-Psrc/opengl/gtkada_gl.gpr
 endif
 


### PR DESCRIPTION
As discuss in issue #5, here is the pull request.