### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+language: cpp
+services:
+ - docker
+
+before_install:
+ - docker pull ubuntu:16.04
+
+script:
+ - docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get -qq update
+RUN apt-get install -y cmake g++ gnat gprbuild pkg-config libgtk-3-dev make
+
+RUN mkdir -p /src/
+WORKDIR /src/
+
+COPY . /src/
+
+RUN ./configure --disable-static-pic --prefix="/src" --with-GL=no --disable-static && make all install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 GtkAda - An Ada graphical toolkit based on Gtk+
 ===============================================
+[![Build Status](https://travis-ci.org/AdaCore/gtkada.svg?branch=master)](https://travis-ci.org/AdaCore/gtkada)
 
 Installation
 ------------


### PR DESCRIPTION
It is advisable to receive feedback after each commit and Travis provides this service free of charge.

It makes use of a file ".travis.yml" and a file "Dockerfile". In the file that needs ".travis.yml" the Docker service is used to launch an image of Ubuntu 16.04 and where the installation of the dependencies and the installation of "gtkada" is executed.

At the moment, the build is failing due to possibly commits introduced by @Nikokrock, because if you move to two commits ago:
`git checkout e7ea8b9d49c669ec9844d042b99f49f79360284d`

The build in Travis works correctly in that specific commit. Also in local running `docker build`.