### PR TITLE
AdaCore gtkada url was not valid anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ General Information
 
 The home page for GtkAda is
 
-  - http://libre.adacore.com/tools/gtkada/
+  - http://docs.adacore.com/live/wave/gtkada/html/gtkada_ug/index.html
 
 The home page for gtk is
 


### PR DESCRIPTION
Seems that this URL is the only relevant documentation that I've found
on their pages along with API Reference.