### PR TITLE
Allow the end user to configure the build via CFLAGS and friends.

### DIFF
--- a/shared.gpr.in
+++ b/shared.gpr.in
@@ -48,6 +48,12 @@ project Shared is
    GL_Include  := Gtk.GL_Default_Include  & (@GL_CFLAGS_GPR@);
    GL_Libs     := Gtk.GL_Default_Libs     & (@GL_LIBS_GPR@);
 
+   Adaflags    := External_As_List ("ADAFLAGS", " ");
+   Cflags      := External_As_List ("CFLAGS", " ");
+   Cppflags    := External_As_List ("CPPFLAGS", " ");
+   Ldflags     := External_As_List ("LDFLAGS", " ");
+   Objcflags   := External_As_List ("OBJCFLAGS", " ");
+
    package Naming is
       for Body_Suffix ("Objective-C") use ".m";
    end Naming;
@@ -73,6 +79,11 @@ project Shared is
 
       for Switches ("C") use Compiler'Switches ("C") & Gtk_Include;
       for Switches ("Objective-C") use Compiler'Switches ("Objective-C") & Gtk_Include;
+
+      for Switches ("Ada") use Compiler'Switches ("Ada") & Adaflags;
+      for Switches ("C") use Compiler'Switches ("C") & Cflags & Cppflags;
+      for Switches ("Objective-C") use Compiler'Switches ("Objective-C")
+        & Objcflags & Cppflags;
    end Compiler;
 
    package Builder is
@@ -94,6 +105,10 @@ project Shared is
              null;
       end case;
    end Binder;
+
+   package Linker is
+      for Leading_Switches ("Ada") use Ldflags;
+   end Linker;
 
    package IDE is
       for VCS_Kind use "auto";

--- a/src/gtkada.gpr
+++ b/src/gtkada.gpr
@@ -62,6 +62,7 @@ library project GtkAda is
 
    case Shared.Library_Kind is
       when "relocatable" =>
+         for Leading_Library_Options use Shared.Ldflags;
          for Library_Options use Shared.Gtk_Libs;
       when others =>
          null;

--- a/src/opengl/gtkada_gl.gpr
+++ b/src/opengl/gtkada_gl.gpr
@@ -42,6 +42,7 @@ library project GtkAda_GL is
 
    case Shared.Library_Kind is
       when "relocatable" =>
+         for Leading_Library_Options use Shared.Ldflags;
          for Library_Options use Shared.GL_Libs & Shared.Gtk_Libs;
       when others =>
          null;

--- a/src/tools/tools.gpr
+++ b/src/tools/tools.gpr
@@ -35,6 +35,7 @@ project Tools is
 
    package Compiler renames Shared.Compiler;
    package Binder   renames Shared.Binder;
+   package Linker   renames Shared.Linker;
    package IDE      renames Shared.IDE;
 
 end Tools;

--- a/testgtk/testgtk.gpr
+++ b/testgtk/testgtk.gpr
@@ -21,6 +21,7 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with "../shared";
 with "../src/gtkada";
 with "opengl/testgtk_opengl";
 with "task_project/task_project";
@@ -35,8 +36,11 @@ project TestGtk is
 
    package Compiler is
       --  subprogram specs not required in testgtk
-      for Switches ("Ada") use ("-g", "-O0", "-gnaty-s", "-gnatwJ");
+      for Switches ("Ada") use ("-g", "-O0", "-gnaty-s", "-gnatwJ")
+         & Shared.Adaflags;
    end Compiler;
+
+   package Linker renames Shared.Linker;
 
    package Install is
       for artifacts ("share/examples/gtkada/testgtk") use


### PR DESCRIPTION
Usually, ./configure reads these values from the environment and
stores them into the generated Makefile, allowing override in both
./configure then Make command lines. A patch copying this has once
been refused, so this commit attempts to be less intrusive. It only
modifies GNAT projects.

CFLAGS and similar take precedence over the default (-O0).

LDFLAGS comes before libraries that they affect (--as-needed).