### PR TITLE
Make linking command BSD compatible (essentially POSIX)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -109,7 +109,7 @@ install: install-clean
 		--mode=usage --exec-subdir=${DESTDIR}${exampledir} \
 		-Ptestgtk.gpr -aP ../src
 ifneq ($(OS),Windows_NT)
-	ln -s ${libdir} ${DESTDIR}${datadir}/examples/gtkada --force
+	ln -sf ${libdir} ${DESTDIR}${datadir}/examples/gtkada
 endif
 	@echo '-----------------------------------------------------------------------'
 	@echo '--  GtkAda has now been installed.                                   --'


### PR DESCRIPTION
This was using the GNU-only option of --force. This change makes it POSIX compatible, thus not failing on BSD (macOS).

POSIX documentiation for `ln`: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ln.html

refs #61 

Additionally, I see this is also solved by #57 , but this is far simpler